### PR TITLE
Update docs and CI jobs with new version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install Riff
         uses: ./
         with:
-          riff-version: "1.0.0"
+          riff-version: "1.0.2"
       - name: Test Riff in a Rust project
         run: |
           git clone https://github.com/DeterminateSystems/riff
@@ -74,7 +74,7 @@ jobs:
       - name: Install Riff
         uses: DeterminateSystems/install-riff-action@v1
         with:
-          riff-version: "1.0.0"
+          riff-version: "1.0.2"
       - name: Test Riff in a Rust project
         run: |
           git clone https://github.com/DeterminateSystems/riff

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           git clone https://github.com/DeterminateSystems/riff
           cd riff
-          riff run cargo build -- --release
+          riff run cargo check
   test-specific-riff-version:
     strategy:
       matrix:
@@ -53,7 +53,7 @@ jobs:
         run: |
           git clone https://github.com/DeterminateSystems/riff
           cd riff
-          riff run cargo build -- --release
+          riff run cargo check
   # This test runs as if it were in a repo outside of this one
   test-action-v1:
     strategy:
@@ -79,5 +79,5 @@ jobs:
         run: |
           git clone https://github.com/DeterminateSystems/riff
           cd riff
-          riff run cargo build -- --release
+          riff run cargo check
 

--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ You can supply a specific Riff version using the `riff-version` parameter:
 - name: Install Riff
   uses: DeterminateSystems/install-riff-action@v1
   with:
-    riff-version: "1.0.0"
+    riff-version: "1.0.2"
 ```
 
-The current default for `riff-version` is `1.0.0`.
+The current default for `riff-version` is `1.0.2`.
 
 ## How it works
 
@@ -62,3 +62,4 @@ install Riff itself.
 [rust]: https://rust-lang.org
 [toolchain]: https://github.com/actions-rs/toolchain
 [install-nix]: https://github.com/cachix/install-nix-action
+

--- a/README.md
+++ b/README.md
@@ -55,7 +55,26 @@ With a Rust toolchain (including [Cargo]) and Nix installed in your pipeline,
 `install-nix-action` runs the [`install-riff.sh`](./install-riff.sh) script to
 install Riff itself.
 
+## Release process
+
+Releases for this Action are tied to [Riff] releases. For each new Riff version:
+
+* Update `inputs.riff-version.default` in [`action.yml`](./action.yml).
+* Update `riff-version` in the [README](./README.md) and in the [CI
+  pipeline][ci].
+* Pull request the changes and merge.
+* Tag the new `HEAD` with the new version (e.g. `v1.2.3`) and push.
+* [Create a new release][create] with the following attributes:
+  * Select the new version tag.
+  * Provide a release title of the form `install-riff-action-v*`, e.g.
+    `install-riff-action-v1.2.3`.
+  * Choose **Dependency Management** as the primary category.
+  * Add a brief release note, e.g. `Release for Riff version v1.2.3`.
+  * Submit the release.
+
 [cargo]: https://doc.rust-lang.org/cargo
+[ci]: ./.github/workflows/test.yml
+[create]: https://github.com/DeterminateSystems/install-riff-action/releases/new
 [flakes]: https://nixos.wiki/wiki/Flakes
 [nix]: https://nixos.org
 [riff]: https://github.com/DeterminateSystems/riff


### PR DESCRIPTION
The docs and CI steps are currently still on version 1.0.0 of Riff. This PR updates everything to the latest version and adds some docs on the release process.